### PR TITLE
Move route to a new file

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,22 @@
+const getConfig = () => {
+	if (process.env.NODE_ENV === 'test') {
+		return {
+			logging: false,
+			STREAMLABS_TOKEN: 'token',
+			STREAMLABS_ENDPOINT: 'https://streamlabs.com/api/v1.0/alerts',
+			port: 8080,
+		};
+	}
+
+	// TODO: Validate arguments before starting
+	return {
+		logging: true,
+		STREAMLABS_TOKEN: process.env['STREAMLABS_TOKEN'],
+		STREAMLABS_ENDPOINT: 'https://streamlabs.com/api/v1.0/alerts',
+		port: process.env['PORT'] || process.env['HTTP_PORT'] || 8080,
+	};
+};
+
+module.exports = {
+	getConfig,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 const { initServer } = require('./server');
 
+// TODO: Validate arguments before starting
 const config = {
 	STREAMLABS_TOKEN: process.env['STREAMLABS_TOKEN'],
+	STREAMLABS_ENDPOINT: 'https://streamlabs.com/api/v1.0/alerts',
 	port: process.env['PORT'] || process.env['HTTP_PORT'] || 8080,
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,6 @@
 const { initServer } = require('./server');
+const { getConfig } = require('./config');
 
-// TODO: Validate arguments before starting
-const config = {
-	STREAMLABS_TOKEN: process.env['STREAMLABS_TOKEN'],
-	STREAMLABS_ENDPOINT: 'https://streamlabs.com/api/v1.0/alerts',
-	port: process.env['PORT'] || process.env['HTTP_PORT'] || 8080,
-};
-
-initServer(config).then(async (server) => {
+initServer(getConfig()).then(async (server) => {
 	await server.start();
 });

--- a/src/routes/github/index.js
+++ b/src/routes/github/index.js
@@ -1,0 +1,75 @@
+const joi = require('@hapi/joi');
+const axios = require('axios');
+
+/**
+ *
+ * @param {any} config
+ */
+const routes = (config) => [
+	{
+		method: 'POST',
+		path: '/github',
+		options: {
+			validate: {
+				headers: joi
+					.object({ 'x-github-event': joi.string().required() })
+					.unknown(),
+				payload: joi
+					.object({
+						action: joi.string(),
+						hook: joi
+							.object({ events: joi.array().items(joi.string()) })
+							.unknown(),
+						sender: joi
+							.object({ login: joi.string().required() })
+							.required()
+							.unknown(),
+						repository: joi
+							.object({ full_name: joi.string().required() })
+							.required()
+							.unknown(),
+					})
+					.unknown(),
+			},
+		},
+		handler: async (request, h) => {
+			const { payload, headers } = request;
+			const event = headers['x-github-event'];
+			const {
+				repository: { full_name: repositoryFullName },
+			} = payload;
+
+			if (event === 'ping' && request.payload.hook.events.includes('star')) {
+				await axios.post(config.STREAMLABS_ENDPOINT, {
+					access_token: config.STREAMLABS_TOKEN,
+					type: 'follow',
+					message: `🎉 Your repo *${repositoryFullName}* is configured correctly for *star* events 🎉`,
+				});
+
+				return h.response().code(200);
+			}
+
+			if (event === 'star' && request.payload.action === 'created') {
+				const {
+					sender: { login: senderLogin },
+				} = payload;
+
+				await axios.post(config.STREAMLABS_ENDPOINT, {
+					access_token: config.STREAMLABS_TOKEN,
+					type: 'follow',
+					message: `*${senderLogin}* just starred *${repositoryFullName}*`,
+				});
+
+				return h.response().code(200);
+			}
+
+			return h.response({
+				message: `Ignoring event: '${event}'`,
+			});
+		},
+	},
+];
+
+module.exports = {
+	routes,
+};

--- a/src/server.js
+++ b/src/server.js
@@ -12,16 +12,18 @@ const initServer = async (config) => {
 		port: config.port,
 	});
 
-	await server.register({
-		plugin: laabr,
-		options: {
-			formats: {
-				'request': 'error.json',
-				'request-error': 'error.stackjson',
-				'uncaught': 'error.stackjson',
+	if (config.logging) {
+		await server.register({
+			plugin: laabr,
+			options: {
+				formats: {
+					'request': 'error.json',
+					'request-error': 'error.stackjson',
+					'uncaught': 'error.stackjson',
+				},
 			},
-		},
-	});
+		});
+	}
 
 	server.route(routes(config));
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,11 +1,6 @@
 const { Server } = require('@hapi/hapi');
-const joi = require('@hapi/joi');
-const axios = require('axios');
+const { routes } = require('./routes/github');
 const laabr = require('laabr');
-
-// TODO: Validate arguments before starting
-
-const STREAMLABS_ENDPOINT = 'https://streamlabs.com/api/v1.0/alerts';
 
 /**
  *
@@ -28,70 +23,7 @@ const initServer = async (config) => {
 		},
 	});
 
-	server.route([
-		{
-			method: 'POST',
-			path: '/github',
-			options: {
-				validate: {
-					headers: joi
-						.object({ 'x-github-event': joi.string().required() })
-						.unknown(),
-					payload: joi
-						.object({
-							action: joi.string(),
-							hook: joi
-								.object({ events: joi.array().items(joi.string()) })
-								.unknown(),
-							sender: joi
-								.object({ login: joi.string().required() })
-								.required()
-								.unknown(),
-							repository: joi
-								.object({ full_name: joi.string().required() })
-								.required()
-								.unknown(),
-						})
-						.unknown(),
-				},
-			},
-			handler: async (request, h) => {
-				const { payload, headers } = request;
-				const event = headers['x-github-event'];
-				const {
-					repository: { full_name: repositoryFullName },
-				} = payload;
-
-				if (event === 'ping' && request.payload.hook.events.includes('star')) {
-					await axios.post(STREAMLABS_ENDPOINT, {
-						access_token: config.STREAMLABS_TOKEN,
-						type: 'follow',
-						message: `🎉 Your repo *${repositoryFullName}* is configured correctly for *star* events 🎉`,
-					});
-
-					return h.response().code(200);
-				}
-
-				if (event === 'star' && request.payload.action === 'created') {
-					const {
-						sender: { login: senderLogin },
-					} = payload;
-
-					await axios.post(STREAMLABS_ENDPOINT, {
-						access_token: config.STREAMLABS_TOKEN,
-						type: 'follow',
-						message: `*${senderLogin}* just starred *${repositoryFullName}*`,
-					});
-
-					return h.response().code(200);
-				}
-
-				return h.response({
-					message: `Ignoring event: '${event}'`,
-				});
-			},
-		},
-	]);
+	server.route(routes(config));
 
 	return server;
 };

--- a/test/routes/github/index.spec.js
+++ b/test/routes/github/index.spec.js
@@ -1,4 +1,5 @@
 const { initServer } = require('../../../src/server');
+const { getConfig } = require('../../../src/config');
 const axios = require('axios');
 
 describe('server', () => {
@@ -7,10 +8,11 @@ describe('server', () => {
 	});
 
 	describe('POST /github', () => {
-		const config = {
-			port: 8080,
-			STREAMLABS_ENDPOINT: 'https://streamlabs.com/api/v1.0/alerts',
-		};
+		let config;
+
+		beforeEach(() => {
+			config = getConfig();
+		});
 
 		it('returns 400 on requests without payload', async () => {
 			const subject = await initServer(config);

--- a/test/routes/github/index.spec.js
+++ b/test/routes/github/index.spec.js
@@ -1,4 +1,4 @@
-const { initServer } = require('../src/server');
+const { initServer } = require('../../../src/server');
 const axios = require('axios');
 
 describe('server', () => {
@@ -7,7 +7,10 @@ describe('server', () => {
 	});
 
 	describe('POST /github', () => {
-		const config = { port: 8080 };
+		const config = {
+			port: 8080,
+			STREAMLABS_ENDPOINT: 'https://streamlabs.com/api/v1.0/alerts',
+		};
 
 		it('returns 400 on requests without payload', async () => {
 			const subject = await initServer(config);


### PR DESCRIPTION
Related to #26 

To prevent a merge hell every time we change our routes, this PR moves all the route definitions to a different file.

Since the route is `GET /github`, I move the route definition to the `routes/github/index.js`, maybe if we have more routes for GitHub, we can split each route into their own file.

Also, this PR prevents the logging system to be set up during the tests.