### PR TITLE
feat: new StreamLabs service

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ const getConfig = () => {
 		return {
 			logging: false,
 			STREAMLABS_TOKEN: 'token',
-			STREAMLABS_ENDPOINT: 'https://streamlabs.com/api/v1.0/alerts',
+			STREAMLABS_ENDPOINT: 'https://streamlabs.com/api/v1.0/alerts', // TODO: remove
 			port: 8080,
 		};
 	}
@@ -12,7 +12,7 @@ const getConfig = () => {
 	return {
 		logging: true,
 		STREAMLABS_TOKEN: process.env['STREAMLABS_TOKEN'],
-		STREAMLABS_ENDPOINT: 'https://streamlabs.com/api/v1.0/alerts',
+		STREAMLABS_ENDPOINT: 'https://streamlabs.com/api/v1.0/alerts', // TODO: remove
 		port: process.env['PORT'] || process.env['HTTP_PORT'] || 8080,
 	};
 };

--- a/src/services/StreamLabs.js
+++ b/src/services/StreamLabs.js
@@ -1,0 +1,20 @@
+const axios = require('axios');
+
+class StreamLabs {
+	constructor({ token }) {
+		this.base = 'https://streamlabs.com/api/v1.0';
+		this.token = token;
+	}
+
+	alert({ message }) {
+		return axios.post(`${this.base}/alerts`, {
+			access_token: this.token,
+			message,
+			type: 'follow',
+		});
+	}
+}
+
+module.exports = {
+	StreamLabs,
+};

--- a/test/services/StreamLabs.spec.js
+++ b/test/services/StreamLabs.spec.js
@@ -1,0 +1,64 @@
+const axios = require('axios');
+const { StreamLabs } = require('../../src/services/StreamLabs');
+
+describe('StreamLabs', () => {
+	describe('#alert', () => {
+		let axiosSpy;
+
+		beforeEach(() => {
+			jest.restoreAllMocks();
+			axiosSpy = jest.spyOn(axios, 'post');
+			axiosSpy.mockImplementationOnce(() => {});
+		});
+
+		it("uses axios to perform a 'POST' to the StreamLabs url", async () => {
+			const config = {
+				token: 'token',
+			};
+			const subject = new StreamLabs(config);
+
+			await subject.alert('alert');
+
+			expect(axiosSpy).toHaveBeenCalledWith(
+				'https://streamlabs.com/api/v1.0/alerts',
+				expect.any(Object),
+			);
+		});
+
+		it("uses the given token as 'access_token'", async () => {
+			const config = {
+				token: 'token',
+			};
+			const subject = new StreamLabs(config);
+
+			await subject.alert({ message: 'alert' });
+
+			expect(axiosSpy).toHaveBeenCalledWith(
+				'https://streamlabs.com/api/v1.0/alerts',
+				expect.objectContaining({ access_token: config.token }),
+			);
+		});
+
+		it("uses the text given as an argument as message to 'StreamLabs'", async () => {
+			const subject = new StreamLabs({});
+
+			await subject.alert({ message: 'alert' });
+
+			expect(axiosSpy).toHaveBeenCalledWith(
+				'https://streamlabs.com/api/v1.0/alerts',
+				expect.objectContaining({ message: 'alert' }),
+			);
+		});
+
+		it("sends the alerts with the type 'follow'", async () => {
+			const subject = new StreamLabs({});
+
+			await subject.alert({ message: 'alert' });
+
+			expect(axiosSpy).toHaveBeenCalledWith(
+				'https://streamlabs.com/api/v1.0/alerts',
+				expect.objectContaining({ type: 'follow' }),
+			);
+		});
+	});
+});


### PR DESCRIPTION
Related to #12 

It's time to avoid repeating the same code to send the notifications to StreamLabs, this PR adds a StreamLabs service with a method to send `alerts`.

P.S.: It's only the implementation, we need to merge all PR related with #26 before we can use it 😜 

