### PR TITLE
refactor: new 'Reaction' abstract class

### DIFF
--- a/src/reactions/github/ping.ts
+++ b/src/reactions/github/ping.ts
@@ -1,6 +1,18 @@
-import { Reaction, ReactionHandleOptions } from './reaction';
+import {
+	Reaction,
+	ReactionCanHandleOptions,
+	ReactionHandleOptions,
+} from './reaction';
 
 export class Ping extends Reaction {
+	canHandle({ payload, event }: ReactionCanHandleOptions): boolean {
+		return (
+			event === 'ping' &&
+			(payload.hook.events.includes('star') ||
+				payload.hook.events.includes('fork') ||
+				payload.hook.events.includes('pull_request'))
+		);
+	}
 	getStreamLabsMessage({ payload }: ReactionHandleOptions): string {
 		return `🎉 Your repo *${payload.repository.full_name}* is configured correctly for *${payload.hook.events}* events 🎉`;
 	}

--- a/src/reactions/github/ping.ts
+++ b/src/reactions/github/ping.ts
@@ -1,74 +1,10 @@
-import { StreamLabs } from '../../services/StreamLabs';
-import { TwitchChat } from '../../services/TwitchChat';
+import { Reaction, ReactionHandleOptions } from './reaction';
 
-interface PingConfig {
-	streamlabs: StreamLabs;
-	twitchChat: TwitchChat;
-}
-
-interface HandleOptions {
-	// FIXME: add Payload type
-	payload: any;
-}
-
-export class Ping {
-	private streamlabs: StreamLabs;
-	private twitchChat: TwitchChat;
-
-	public constructor({ streamlabs, twitchChat }: PingConfig) {
-		this.streamlabs = streamlabs;
-		this.twitchChat = twitchChat;
+export class Ping extends Reaction {
+	getStreamLabsMessage({ payload }: ReactionHandleOptions): string {
+		return `🎉 Your repo *${payload.repository.full_name}* is configured correctly for *${payload.hook.events}* events 🎉`;
 	}
-
-	private async notifyStreamlabs({ payload }: HandleOptions) {
-		try {
-			const streamlabsMessage = `🎉 Your repo *${payload.repository.full_name}* is configured correctly for *${payload.hook.events}* events 🎉`;
-			await this.streamlabs.alert({
-				message: streamlabsMessage,
-			});
-
-			return {
-				notified: true,
-				message: streamlabsMessage,
-			};
-		} catch {
-			// TODO: add logging
-
-			return {
-				notified: false,
-				message: '',
-			};
-		}
-	}
-
-	private async notifyTwitch({ payload }: HandleOptions) {
-		try {
-			const message = `🎉 Your repo *${payload.repository.full_name}* is configured correctly for *${payload.hook.events}* events 🎉`;
-			await this.twitchChat.send(message);
-
-			return {
-				notified: true,
-				message,
-			};
-		} catch {
-			// TODO: add logging
-
-			return {
-				notified: false,
-				message: '',
-			};
-		}
-	}
-
-	public async handle({ payload }: HandleOptions) {
-		const [streamlabs, twitchChat] = await Promise.all([
-			this.notifyStreamlabs({ payload }),
-			this.notifyTwitch({ payload }),
-		]);
-
-		return {
-			twitchChat,
-			streamlabs,
-		};
+	getTwitchChatMessage({ payload }: ReactionHandleOptions): string {
+		return `🎉 Your repo *${payload.repository.full_name}* is configured correctly for *${payload.hook.events}* events 🎉`;
 	}
 }

--- a/src/reactions/github/pull-request-opened.ts
+++ b/src/reactions/github/pull-request-opened.ts
@@ -1,63 +1,10 @@
-import { TwitchChat } from '../../services/TwitchChat';
-import { StreamLabs } from '../../services/StreamLabs';
+import { Reaction, ReactionHandleOptions } from './reaction';
 
-interface HandleOptions {
-	payload: any;
-}
-
-export class PullRequestOpened {
-	public constructor(
-		private twitchChat: TwitchChat,
-		private streamlabs: StreamLabs,
-	) {}
-
-	private async notifyTwitch({ payload }: HandleOptions) {
-		try {
-			const message = `*${payload.pull_request.user.login}* just opened a pull request in ${payload.repository.html_url}`;
-			await this.twitchChat.send(message);
-
-			return {
-				notified: true,
-				message,
-			};
-		} catch {
-			// TODO: add logging
-
-			return {
-				notified: false,
-				message: '',
-			};
-		}
+export class PullRequestOpened extends Reaction {
+	getStreamLabsMessage({ payload }: ReactionHandleOptions): string {
+		return `*${payload.pull_request.user.login}* just opened a pull request in *${payload.repository.full_name}*`;
 	}
-
-	public async notifyStreamLabs({ payload }: HandleOptions) {
-		try {
-			const message = `*${payload.pull_request.user.login}* just opened a pull request in *${payload.repository.full_name}*`;
-			await this.streamlabs.alert({ message });
-
-			return {
-				notified: true,
-				message,
-			};
-		} catch {
-			// TODO: add logging
-
-			return {
-				notified: false,
-				message: '',
-			};
-		}
-	}
-
-	public async handle({ payload }: HandleOptions) {
-		const [twitchChat, streamlabs] = await Promise.all([
-			this.notifyTwitch({ payload }),
-			this.notifyStreamLabs({ payload }),
-		]);
-
-		return {
-			twitchChat,
-			streamlabs,
-		};
+	getTwitchChatMessage({ payload }: ReactionHandleOptions): string {
+		return `*${payload.pull_request.user.login}* just opened a pull request in ${payload.repository.html_url}`;
 	}
 }

--- a/src/reactions/github/pull-request-opened.ts
+++ b/src/reactions/github/pull-request-opened.ts
@@ -1,6 +1,13 @@
-import { Reaction, ReactionHandleOptions } from './reaction';
+import {
+	Reaction,
+	ReactionCanHandleOptions,
+	ReactionHandleOptions,
+} from './reaction';
 
 export class PullRequestOpened extends Reaction {
+	canHandle({ payload, event }: ReactionCanHandleOptions): boolean {
+		return event === 'pull_request' && payload.action === 'opened';
+	}
 	getStreamLabsMessage({ payload }: ReactionHandleOptions): string {
 		return `*${payload.pull_request.user.login}* just opened a pull request in *${payload.repository.full_name}*`;
 	}

--- a/src/reactions/github/reaction.ts
+++ b/src/reactions/github/reaction.ts
@@ -6,6 +6,11 @@ export interface ReactionHandleOptions {
 	payload: any;
 }
 
+export interface ReactionCanHandleOptions {
+	payload: any;
+	event: string;
+}
+
 export abstract class Reaction {
 	public constructor(
 		private twitchChat: TwitchChat,
@@ -14,6 +19,7 @@ export abstract class Reaction {
 
 	abstract getStreamLabsMessage({ payload }: ReactionHandleOptions): string;
 	abstract getTwitchChatMessage({ payload }: ReactionHandleOptions): string;
+	abstract canHandle({ payload, event }: ReactionCanHandleOptions): boolean;
 
 	private async notifyStreamlabs({ payload }: ReactionHandleOptions) {
 		try {

--- a/src/reactions/github/reaction.ts
+++ b/src/reactions/github/reaction.ts
@@ -1,0 +1,69 @@
+import { StreamLabs } from '../../services/StreamLabs';
+import { TwitchChat } from '../../services/TwitchChat';
+
+export interface ReactionHandleOptions {
+	// FIXME: add Payload type
+	payload: any;
+}
+
+export abstract class Reaction {
+	public constructor(
+		private twitchChat: TwitchChat,
+		private streamlabs: StreamLabs,
+	) {}
+
+	abstract getStreamLabsMessage({ payload }: ReactionHandleOptions): string;
+	abstract getTwitchChatMessage({ payload }: ReactionHandleOptions): string;
+
+	private async notifyStreamlabs({ payload }: ReactionHandleOptions) {
+		try {
+			const message = this.getStreamLabsMessage({ payload });
+			await this.streamlabs.alert({
+				message,
+			});
+
+			return {
+				notified: true,
+				message,
+			};
+		} catch {
+			// TODO: add logging
+
+			return {
+				notified: false,
+				message: '',
+			};
+		}
+	}
+
+	private async notifyTwitch({ payload }: ReactionHandleOptions) {
+		try {
+			const message = this.getTwitchChatMessage({ payload });
+			await this.twitchChat.send(message);
+
+			return {
+				notified: true,
+				message,
+			};
+		} catch {
+			// TODO: add logging
+
+			return {
+				notified: false,
+				message: '',
+			};
+		}
+	}
+
+	public async handle({ payload }: ReactionHandleOptions) {
+		const [streamlabs, twitchChat] = await Promise.all([
+			this.notifyStreamlabs({ payload }),
+			this.notifyTwitch({ payload }),
+		]);
+
+		return {
+			twitchChat,
+			streamlabs,
+		};
+	}
+}

--- a/src/reactions/github/star.ts
+++ b/src/reactions/github/star.ts
@@ -1,6 +1,14 @@
-import { Reaction, ReactionHandleOptions } from './reaction';
+import {
+	Reaction,
+	ReactionCanHandleOptions,
+	ReactionHandleOptions,
+} from './reaction';
 
 export class Star extends Reaction {
+	canHandle({ payload, event }: ReactionCanHandleOptions): boolean {
+		return event === 'star' && payload.action === 'created';
+	}
+
 	getStreamLabsMessage({ payload }: ReactionHandleOptions): string {
 		return `*${payload.sender.login}* just starred *${payload.repository.full_name}*`;
 	}

--- a/src/reactions/github/star.ts
+++ b/src/reactions/github/star.ts
@@ -1,63 +1,11 @@
-import { TwitchChat } from '../../services/TwitchChat';
-import { StreamLabs } from '../../services/StreamLabs';
+import { Reaction, ReactionHandleOptions } from './reaction';
 
-interface HandleOptions {
-	payload: any;
-}
-
-export class Star {
-	public constructor(
-		private twitchChat: TwitchChat,
-		private streamlabs: StreamLabs,
-	) {}
-
-	private async notifyTwitch({ payload }: HandleOptions) {
-		try {
-			const message = `*${payload.sender.login}* just starred ${payload.repository.html_url}`;
-			await this.twitchChat.send(message);
-
-			return {
-				notified: true,
-				message,
-			};
-		} catch {
-			// TODO: add logging
-
-			return {
-				notified: false,
-				message: '',
-			};
-		}
+export class Star extends Reaction {
+	getStreamLabsMessage({ payload }: ReactionHandleOptions): string {
+		return `*${payload.sender.login}* just starred *${payload.repository.full_name}*`;
 	}
 
-	private async notifyStreamLabs({ payload }: HandleOptions) {
-		try {
-			const message = `*${payload.sender.login}* just starred *${payload.repository.full_name}*`;
-			await this.streamlabs.alert({ message });
-
-			return {
-				notified: true,
-				message,
-			};
-		} catch {
-			// TODO: add logging
-
-			return {
-				notified: false,
-				message: '',
-			};
-		}
-	}
-
-	public async handle({ payload }: HandleOptions) {
-		const [twitchChat, streamlabs] = await Promise.all([
-			this.notifyTwitch({ payload }),
-			this.notifyStreamLabs({ payload }),
-		]);
-
-		return {
-			twitchChat,
-			streamlabs,
-		};
+	getTwitchChatMessage({ payload }: ReactionHandleOptions): string {
+		return `*${payload.sender.login}* just starred ${payload.repository.html_url}`;
 	}
 }

--- a/test/reactions/github/ping.spec.ts
+++ b/test/reactions/github/ping.spec.ts
@@ -106,4 +106,61 @@ describe('Ping', () => {
 			expect(notified).toEqual(false);
 		});
 	});
+
+	describe('#canHandle', () => {
+		it('returns true if the event is ping and the hook.events array contains star', () => {
+			const subject = new Ping(null as any, null as any);
+
+			const result = subject.canHandle({
+				event: 'ping',
+				payload: { hook: { events: ['star'] } },
+			});
+
+			expect(result).toEqual(true);
+		});
+
+		it('returns false if the event is not ping', () => {
+			const subject = new Ping(null as any, null as any);
+
+			const result = subject.canHandle({
+				event: 'fork',
+				payload: { hook: { events: ['star'] } },
+			});
+
+			expect(result).toEqual(false);
+		});
+
+		it('returns false if the hook.events only contains status', () => {
+			const subject = new Ping(null as any, null as any);
+
+			const result = subject.canHandle({
+				event: 'ping',
+				payload: { hook: { events: ['status'] } },
+			});
+
+			expect(result).toEqual(false);
+		});
+
+		it('returns true if the event is ping and the hook.events array contains fork', () => {
+			const subject = new Ping(null as any, null as any);
+
+			const result = subject.canHandle({
+				event: 'ping',
+				payload: { hook: { events: ['fork'] } },
+			});
+
+			expect(result).toEqual(true);
+		});
+
+		it('returns true if the event is ping and the hook.events array contains pull_request', () => {
+			const subject = new Ping(null as any, null as any);
+
+			const result = subject.canHandle({
+				event: 'ping',
+				payload: { hook: { events: ['pull_request'] } },
+			});
+
+			expect(result).toEqual(true);
+		});
+	});
 });

--- a/test/reactions/github/ping.spec.ts
+++ b/test/reactions/github/ping.spec.ts
@@ -25,7 +25,7 @@ describe('Ping', () => {
 		});
 
 		it('calls StreamLabs with the expected message', async () => {
-			const subject = new Ping({ streamlabs, twitchChat });
+			const subject = new Ping(twitchChat, streamlabs);
 
 			await subject.handle({ payload });
 
@@ -35,7 +35,7 @@ describe('Ping', () => {
 		});
 
 		it('calls TwitchChat with the expected message', async () => {
-			const subject = new Ping({ streamlabs, twitchChat });
+			const subject = new Ping(twitchChat, streamlabs);
 
 			await subject.handle({ payload });
 
@@ -45,7 +45,7 @@ describe('Ping', () => {
 		});
 
 		it('returns the message that was send to Twitch', async () => {
-			const subject = new Ping({ streamlabs, twitchChat });
+			const subject = new Ping(twitchChat, streamlabs);
 
 			const { twitchChat: response } = await subject.handle({
 				payload: {
@@ -63,7 +63,7 @@ describe('Ping', () => {
 		});
 
 		it('returns the message that was send to StreamLabs', async () => {
-			const subject = new Ping({ streamlabs, twitchChat });
+			const subject = new Ping(twitchChat, streamlabs);
 
 			const { streamlabs: response } = await subject.handle({
 				payload: {
@@ -84,7 +84,7 @@ describe('Ping', () => {
 			jest.spyOn(streamlabs, 'alert').mockImplementationOnce(async () => {
 				throw new Error('boom');
 			});
-			const subject = new Ping({ streamlabs, twitchChat });
+			const subject = new Ping(twitchChat, streamlabs);
 
 			const {
 				streamlabs: { notified },
@@ -97,7 +97,7 @@ describe('Ping', () => {
 			jest.spyOn(twitchChat, 'send').mockImplementationOnce(async () => {
 				throw new Error('boom');
 			});
-			const subject = new Ping({ streamlabs, twitchChat });
+			const subject = new Ping(twitchChat, streamlabs);
 
 			const {
 				twitchChat: { notified },

--- a/test/reactions/github/pull-request-opened.spec.ts
+++ b/test/reactions/github/pull-request-opened.spec.ts
@@ -79,4 +79,39 @@ describe('PullRequestOpened', () => {
 			});
 		});
 	});
+
+	describe('#canHandle', () => {
+		it('returns true if the pull request is opened', () => {
+			const subject = new PullRequestOpened(null as any, null as any);
+
+			const result = subject.canHandle({
+				event: 'pull_request',
+				payload: { action: 'opened' },
+			});
+
+			expect(result).toEqual(true);
+		});
+
+		it('returns false if the event is not pull request', () => {
+			const subject = new PullRequestOpened(null as any, null as any);
+
+			const result = subject.canHandle({
+				event: 'fork',
+				payload: { action: 'opened' },
+			});
+
+			expect(result).toEqual(false);
+		});
+
+		it('returns false if the pull request is closed', () => {
+			const subject = new PullRequestOpened(null as any, null as any);
+
+			const result = subject.canHandle({
+				event: 'pull_request',
+				payload: { action: 'closed' },
+			});
+
+			expect(result).toEqual(false);
+		});
+	});
 });

--- a/test/reactions/github/star.spec.ts
+++ b/test/reactions/github/star.spec.ts
@@ -81,4 +81,28 @@ describe('Star', () => {
 			});
 		});
 	});
+
+	describe('#canHandle', () => {
+		it('returns true if the event is star and actions is created', () => {
+			const subject = new Star(null as any, null as any);
+
+			const result = subject.canHandle({
+				event: 'star',
+				payload: { action: 'created' },
+			});
+
+			expect(result).toEqual(true);
+		});
+
+		it('returns false if the event is star and actions is removed', () => {
+			const subject = new Star(null as any, null as any);
+
+			const result = subject.canHandle({
+				event: 'star',
+				payload: { action: 'removed' },
+			});
+
+			expect(result).toEqual(false);
+		});
+	});
 });


### PR DESCRIPTION
Related to #50 

This PR creates the new `Reaction` abstract class with all the common logic that we found while we create the reactions: `star`, `pull-request-opened` and `ping`.

It also adds to all `Reactions` the new `canHandle` method as we discussed yesterday :D