### PR TITLE
refactor: Migrate fork to TypeScript

### DIFF
--- a/src/reactions/github/fork.ts
+++ b/src/reactions/github/fork.ts
@@ -1,16 +1,16 @@
-import {ForkPayload} from '../../schemas/github/fork-payload';
-import {Reaction, ReactionCanHandleOptions} from "./reaction";
+import { ForkPayload } from '../../schemas/github/fork-payload';
+import { Reaction, ReactionCanHandleOptions } from './reaction';
 
 export class Fork extends Reaction {
-	canHandle({payload, event}: ReactionCanHandleOptions): boolean {
+	canHandle({ payload, event }: ReactionCanHandleOptions): boolean {
 		return event === 'fork';
 	}
 
-	getStreamLabsMessage({payload}: { payload: ForkPayload }): string {
+	getStreamLabsMessage({ payload }: { payload: ForkPayload }): string {
 		return `*${payload.forkee.owner.login}* just forked 🍴 *${payload.repository.full_name}*`;
 	}
 
-	getTwitchChatMessage({payload}: { payload: ForkPayload }): string {
+	getTwitchChatMessage({ payload }: { payload: ForkPayload }): string {
 		return `*${payload.forkee.owner.login}* just forked 🍴 ${payload.repository.html_url}`;
 	}
 }

--- a/src/reactions/github/fork.ts
+++ b/src/reactions/github/fork.ts
@@ -1,41 +1,16 @@
-import { StreamLabs } from '../../services/StreamLabs';
-import { TwitchChat } from '../../services/TwitchChat';
-import { ForkPayload } from '../../schemas/github/fork-payload';
+import {ForkPayload} from '../../schemas/github/fork-payload';
+import {Reaction, ReactionCanHandleOptions} from "./reaction";
 
-export class Fork {
-	static canHandle({ event }: { event: string }) {
+export class Fork extends Reaction {
+	canHandle({payload, event}: ReactionCanHandleOptions): boolean {
 		return event === 'fork';
 	}
 
-	constructor(private streamlabs: StreamLabs, private twitchChat: TwitchChat) {}
+	getStreamLabsMessage({payload}: { payload: ForkPayload }): string {
+		return `*${payload.forkee.owner.login}* just forked 🍴 *${payload.repository.full_name}*`;
+	}
 
-	async handle({ payload }: { payload: ForkPayload }) {
-		const {
-			repository: { full_name: repositoryFullName, html_url: repositoryUrl },
-			forkee: {
-				owner: { login: ownerLogin },
-			},
-		} = payload;
-
-		const streamLabsMessage = `*${ownerLogin}* just forked 🍴 *${repositoryFullName}*`;
-		const twitchChatMessage = `*${ownerLogin}* just forked 🍴 ${repositoryUrl}`;
-
-		await this.streamlabs.alert({
-			message: streamLabsMessage,
-		});
-		await this.twitchChat.send(
-			`*${ownerLogin}* just forked 🍴 ${repositoryUrl}`,
-		);
-
-		return {
-			twitchChat: {
-				message: twitchChatMessage,
-				notified: true,
-			},
-			streamLabs: {
-				message: streamLabsMessage,
-				notified: true,
-			},
-		};
+	getTwitchChatMessage({payload}: { payload: ForkPayload }): string {
+		return `*${payload.forkee.owner.login}* just forked 🍴 ${payload.repository.html_url}`;
 	}
 }

--- a/src/reactions/github/fork.ts
+++ b/src/reactions/github/fork.ts
@@ -1,10 +1,15 @@
-class Fork {
-	constructor({ streamlabs, twitchChat }) {
-		this.streamlabs = streamlabs;
-		this.twitchChat = twitchChat;
+import { StreamLabs } from '../../services/StreamLabs';
+import { TwitchChat } from '../../services/TwitchChat';
+import { ForkPayload } from '../../schemas/github/fork-payload';
+
+export class Fork {
+	static canHandle({ event }: { event: string }) {
+		return event === 'fork';
 	}
 
-	async handle({ payload }) {
+	constructor(private streamlabs: StreamLabs, private twitchChat: TwitchChat) {}
+
+	async handle({ payload }: { payload: ForkPayload }) {
 		const {
 			repository: { full_name: repositoryFullName, html_url: repositoryUrl },
 			forkee: {
@@ -34,7 +39,3 @@ class Fork {
 		};
 	}
 }
-
-module.exports = {
-	Fork,
-};

--- a/src/reactions/github/index.js
+++ b/src/reactions/github/index.js
@@ -1,5 +1,0 @@
-const { Fork } = require('./fork');
-
-module.exports = {
-	Fork,
-};

--- a/src/reactions/github/index.ts
+++ b/src/reactions/github/index.ts
@@ -1,0 +1,5 @@
+import { Fork } from './fork';
+
+export * from './fork';
+
+export const reactions = [Fork];

--- a/src/routes/github/index.ts
+++ b/src/routes/github/index.ts
@@ -102,10 +102,9 @@ export const routes = (config: Config) => [
 				);
 			}
 
-
 			const forkReaction = new Fork(twitchChat, streamlabs);
 			if (forkReaction.canHandle({ payload, event })) {
-				const status = forkReaction.handle({payload});
+				const status = forkReaction.handle({ payload });
 
 				return h.response({
 					message: `Event ${event} handled correctly`,

--- a/src/routes/github/index.ts
+++ b/src/routes/github/index.ts
@@ -102,9 +102,10 @@ export const routes = (config: Config) => [
 				);
 			}
 
-			if (Fork.canHandle({ event })) {
-				const handler = new Fork(streamlabs, twitchChat);
-				const status = await handler.handle({ payload });
+
+			const forkReaction = new Fork(twitchChat, streamlabs);
+			if (forkReaction.canHandle({ payload, event })) {
+				const status = forkReaction.handle({payload});
 
 				return h.response({
 					message: `Event ${event} handled correctly`,

--- a/src/routes/github/index.ts
+++ b/src/routes/github/index.ts
@@ -102,8 +102,8 @@ export const routes = (config: Config) => [
 				);
 			}
 
-			if (event === 'fork') {
-				const handler = new Fork({ streamlabs, twitchChat });
+			if (Fork.canHandle({ event })) {
+				const handler = new Fork(streamlabs, twitchChat);
 				const status = await handler.handle({ payload });
 
 				return h.response({

--- a/src/schemas/github/fork-payload.ts
+++ b/src/schemas/github/fork-payload.ts
@@ -1,0 +1,9 @@
+import { WebhookPayload } from './webhook-payload';
+
+export interface ForkPayload extends WebhookPayload {
+	forkee: {
+		owner: {
+			login: string;
+		};
+	};
+}

--- a/src/schemas/github/webhook-payload.ts
+++ b/src/schemas/github/webhook-payload.ts
@@ -1,0 +1,4 @@
+export interface WebhookPayload {
+	repository: { html_url: string; full_name: string };
+	sender: { login: string };
+}

--- a/test/reactions/github/fork.spec.ts
+++ b/test/reactions/github/fork.spec.ts
@@ -52,12 +52,7 @@ describe('Fork', () => {
 			const subject = new Fork(twitchChat, streamlabs);
 
 			const { streamlabs: response } = await subject.handle({
-				payload: {
-					...payload,
-					hook: {
-						events: ['star'],
-					},
-				},
+				payload,
 			});
 
 			expect(response).toEqual({
@@ -70,12 +65,7 @@ describe('Fork', () => {
 			const subject = new Fork(twitchChat, streamlabs);
 
 			const { twitchChat: response } = await subject.handle({
-				payload: {
-					...payload,
-					hook: {
-						events: ['pull_request'],
-					},
-				},
+				payload,
 			});
 
 			expect(response).toEqual({

--- a/test/reactions/github/fork.spec.ts
+++ b/test/reactions/github/fork.spec.ts
@@ -1,7 +1,7 @@
 import { StreamLabs } from '../../../src/services/StreamLabs';
 import { TwitchChat } from '../../../src/services/TwitchChat';
-import {ForkPayload} from "../../../src/schemas/github/fork-payload";
-import {Fork} from "../../../src/reactions/github";
+import { ForkPayload } from '../../../src/schemas/github/fork-payload';
+import { Fork } from '../../../src/reactions/github';
 
 describe('Fork', () => {
 	let payload: ForkPayload;
@@ -14,7 +14,7 @@ describe('Fork', () => {
 		payload = {
 			repository: {
 				full_name: 'streamdevs/webhook',
-				html_url: 'https://github.com/streamdevs/webhook'
+				html_url: 'https://github.com/streamdevs/webhook',
 			},
 			forkee: {
 				owner: {
@@ -28,7 +28,6 @@ describe('Fork', () => {
 	});
 
 	describe('#handle', () => {
-
 		it('calls StreamLabs with the expected message', async () => {
 			const subject = new Fork(twitchChat, streamlabs);
 
@@ -80,7 +79,7 @@ describe('Fork', () => {
 			});
 
 			expect(response).toEqual({
-				message:`*${payload.forkee.owner.login}* just forked 🍴 ${payload.repository.html_url}`,
+				message: `*${payload.forkee.owner.login}* just forked 🍴 ${payload.repository.html_url}`,
 				notified: true,
 			});
 		});
@@ -116,7 +115,7 @@ describe('Fork', () => {
 		it('returns true if the event is fork', () => {
 			const subject = new Fork(null as any, null as any);
 
-			const result = subject.canHandle({payload, event: 'fork'});
+			const result = subject.canHandle({ payload, event: 'fork' });
 
 			expect(result).toEqual(true);
 		});
@@ -124,7 +123,7 @@ describe('Fork', () => {
 		it('returns false if the event is not fork', () => {
 			const subject = new Fork(null as any, null as any);
 
-			const result = subject.canHandle({payload: null, event: 'ping'});
+			const result = subject.canHandle({ payload: null, event: 'ping' });
 
 			expect(result).toEqual(false);
 		});

--- a/test/reactions/github/fork.spec.ts
+++ b/test/reactions/github/fork.spec.ts
@@ -1,0 +1,132 @@
+import { StreamLabs } from '../../../src/services/StreamLabs';
+import { TwitchChat } from '../../../src/services/TwitchChat';
+import {ForkPayload} from "../../../src/schemas/github/fork-payload";
+import {Fork} from "../../../src/reactions/github";
+
+describe('Fork', () => {
+	let payload: ForkPayload;
+	let streamlabs: StreamLabs;
+	let twitchChat: TwitchChat;
+
+	beforeEach(() => {
+		streamlabs = ({ alert: jest.fn() } as unknown) as StreamLabs;
+		twitchChat = ({ send: jest.fn() } as unknown) as TwitchChat;
+		payload = {
+			repository: {
+				full_name: 'streamdevs/webhook',
+				html_url: 'https://github.com/streamdevs/webhook'
+			},
+			forkee: {
+				owner: {
+					login: 'orestes',
+				},
+			},
+			sender: {
+				login: 'orestes',
+			},
+		};
+	});
+
+	describe('#handle', () => {
+
+		it('calls StreamLabs with the expected message', async () => {
+			const subject = new Fork(twitchChat, streamlabs);
+
+			await subject.handle({ payload });
+
+			expect(streamlabs.alert).toHaveBeenCalledWith({
+				message: `*${payload.forkee.owner.login}* just forked 🍴 *${payload.repository.full_name}*`,
+			});
+		});
+
+		it('calls TwitchChat with the expected message', async () => {
+			const subject = new Fork(twitchChat, streamlabs);
+
+			await subject.handle({ payload });
+
+			expect(twitchChat.send).toHaveBeenCalledWith(
+				`*${payload.forkee.owner.login}* just forked 🍴 ${payload.repository.html_url}`,
+			);
+		});
+
+		it('returns the message that was send to StreamLabs', async () => {
+			const subject = new Fork(twitchChat, streamlabs);
+
+			const { streamlabs: response } = await subject.handle({
+				payload: {
+					...payload,
+					hook: {
+						events: ['star'],
+					},
+				},
+			});
+
+			expect(response).toEqual({
+				message: `*${payload.forkee.owner.login}* just forked 🍴 *${payload.repository.full_name}*`,
+				notified: true,
+			});
+		});
+
+		it('returns the message that was send to Twitch', async () => {
+			const subject = new Fork(twitchChat, streamlabs);
+
+			const { twitchChat: response } = await subject.handle({
+				payload: {
+					...payload,
+					hook: {
+						events: ['pull_request'],
+					},
+				},
+			});
+
+			expect(response).toEqual({
+				message:`*${payload.forkee.owner.login}* just forked 🍴 ${payload.repository.html_url}`,
+				notified: true,
+			});
+		});
+
+		it("returns 'streamlabs.notified' set to false is something goes wrong with StreamLabs", async () => {
+			jest.spyOn(streamlabs, 'alert').mockImplementationOnce(async () => {
+				throw new Error('boom');
+			});
+			const subject = new Fork(twitchChat, streamlabs);
+
+			const {
+				streamlabs: { notified },
+			} = await subject.handle({ payload });
+
+			expect(notified).toEqual(false);
+		});
+
+		it("returns 'twitchChat.notified' set to false is something goes wrong with TwitchChat", async () => {
+			jest.spyOn(twitchChat, 'send').mockImplementationOnce(async () => {
+				throw new Error('boom');
+			});
+			const subject = new Fork(twitchChat, streamlabs);
+
+			const {
+				twitchChat: { notified },
+			} = await subject.handle({ payload });
+
+			expect(notified).toEqual(false);
+		});
+	});
+
+	describe('#canHandle', () => {
+		it('returns true if the event is fork', () => {
+			const subject = new Fork(null as any, null as any);
+
+			const result = subject.canHandle({payload, event: 'fork'});
+
+			expect(result).toEqual(true);
+		});
+
+		it('returns false if the event is not fork', () => {
+			const subject = new Fork(null as any, null as any);
+
+			const result = subject.canHandle({payload: null, event: 'ping'});
+
+			expect(result).toEqual(false);
+		});
+	});
+});


### PR DESCRIPTION
Related to #50

This PR does a couple of things (I know, I know 🙏🙏🙏)

- Migrates the barrel file `reactions/github/index.js` to TypeScript
- Implements the new Reaction interface for GitHub's `fork` events
- Introduces the partial typings for GitHub's Webhook `fork` event's payloads