### PR TITLE
chore: Disable JS compilation 

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,5 +63,5 @@
 		/* Advanced Options */
 		"forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
 	},
-	"exclude": ["prettier.config.js", "dist/*"]
+	"exclude": ["dist/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
 		"target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
 		"module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
 		// "lib": [],                             /* Specify library files to be included in the compilation. */
-		"allowJs": true /* Allow javascript files to be compiled. */,
+		"allowJs": false /* Allow javascript files to be compiled. */,
 		// "checkJs": true /* Report errors in .js files. */,
 		// "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
 		// "declaration": true,                   /* Generates corresponding '.d.ts' file. */


### PR DESCRIPTION
Related to #50 

This PR disables JS compilation in `tsc`
It also removes a redundant exclude of the config file for `prettier`