### PR TITLE
fix: Preload dotenv/config so .env variables are loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"compile:check": "yarn compile --noEmit",
 		"test": "jest",
 		"test:watch": "jest --watch",
-		"start": "node dist/index.js",
+		"start": "node -r dotenv/config dist/index.js",
 		"ci:lint": "eslint --ext .ts --ignore-path .gitignore .",
 		"ci:format": "prettier --ignore-path .gitignore -l .",
 		"lint": "yarn run ci:lint --fix",


### PR DESCRIPTION
Fixes #165 