### PR TITLE
fix: allow 'check_run' to work without env var

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,7 @@ export const getConfig = (): Config => {
 		TWITCH_BOT_TOKEN: process.env['TWITCH_BOT_TOKEN'],
 		TWITCH_BOT_CHANNEL: process.env['TWITCH_BOT_CHANNEL'],
 		port: process.env['PORT'] || process.env['HTTP_PORT'] || 8080,
-		NOTIFY_CHECK_RUNS_FOR: (process.env['NOTIFY_CHECK_RUNS_FOR'] || '').split(','),
+		NOTIFY_CHECK_RUNS_FOR: process.env['NOTIFY_CHECK_RUNS_FOR']?.split(',') || [],
 		NOTIFY_ISSUES_ASSIGNED_TO: process.env['NOTIFY_ISSUES_ASSIGNED_TO']?.split(',') || [],
 		IGNORE_PR_OPENED_BY: process.env['IGNORE_PR_OPENED_BY']?.split(',') || [],
 	};


### PR DESCRIPTION
Resolves #176 

Our previous implementation doesn't provide us with an empty array when the env var is not set 😱
![image](https://user-images.githubusercontent.com/7255298/80919137-b5892280-8d68-11ea-8be4-3b1f06185893.png)
